### PR TITLE
OAuth logic.

### DIFF
--- a/Sources/RxOAuth/RxOAuth+Payload.swift
+++ b/Sources/RxOAuth/RxOAuth+Payload.swift
@@ -1,0 +1,36 @@
+import RxSwift
+
+public enum OAuthError: Error {
+    case tokenInvalidated
+}
+
+public protocol OAuthResponseRepresentable {
+    associatedtype PayloadType
+
+    var response: OAuthResponse<PayloadType> {
+        get
+    }
+}
+
+extension OAuthResponse: OAuthResponseRepresentable {
+    public var response: OAuthResponse<Payload> {
+        return self
+    }
+}
+
+extension OAuthResponse {
+    public func payload() throws -> Payload {
+        switch self {
+        case .success(let payload):
+            return payload
+        case .tokenInvalidated:
+            throw OAuthError.tokenInvalidated
+        }
+    }
+}
+
+extension PrimitiveSequenceType where ElementType: OAuthResponseRepresentable {
+    public func payload() -> PrimitiveSequence<TraitType, ElementType.PayloadType> {
+        return self.primitiveSequence.map { try $0.response.payload() }
+    }
+}

--- a/Sources/RxOAuth/RxOAuth.swift
+++ b/Sources/RxOAuth/RxOAuth.swift
@@ -1,0 +1,195 @@
+import RxSwift
+import RxCocoa
+import RxFeedback
+
+public enum OAuthResponse<Payload> {
+    case success(Payload)
+    case tokenInvalidated
+}
+
+public enum TokenState<Token: Equatable> {
+    case fresh(Version<Token>)
+    case refreshing(Version<Token>)
+    case refreshFailed(Version<Token>, lastError: Error)
+    case tokenInvalidated(Version<Token>)
+}
+
+public enum Event<Token> {
+    case refresh(Version<Token>)
+    case tokenRefreshed(SingleEvent<OAuthResponse<Token>>)
+}
+
+extension TokenState {
+    static func reduce(state: TokenState<Token>, event: Event<Token>) -> TokenState<Token> {
+        switch event {
+        case .refresh(let version):
+            switch state {
+            case .tokenInvalidated:
+                return state
+            default:
+                if version == state.token {
+                    return .refreshing(version)
+                }
+            }
+        case .tokenRefreshed(.success(.success(let token))):
+            return .fresh(Version(token))
+        case .tokenRefreshed(.success(.tokenInvalidated)):
+            return .tokenInvalidated(Version(state.token.value))
+        case .tokenRefreshed(.error(let error)):
+            return .refreshFailed(Version(state.token.value), lastError: error)
+        }
+
+        return state
+    }
+}
+
+public enum OAuth<Token: Equatable> {
+    public typealias Feedback = (Driver<TokenState<Token>>) -> Driver<Event<Token>>
+
+    /**
+     Implementation of OAuth feedback loops when using external persistent token storage.
+
+     e.g. Token is stored in database.
+    */
+    public static func feedback(
+        refreshToken: @escaping (Token) -> Single<OAuthResponse<Token>>,
+        shouldRefreshNow: @escaping (Token) -> Bool,
+        authenticated: @escaping (OAuthExecutor<Token>) -> ()
+    ) -> Feedback {
+        let initiateRefreshProcessFeedback: Feedback = { state in
+            let invalidTokenEvent = PublishSubject<Event<Token>>()
+            let refreshTokenNow: (Version<Token>) -> () = { (token) in invalidTokenEvent.on(.next(.refresh(token))) }
+
+            authenticated(OAuthExecutor(state: state, refreshToken: refreshTokenNow, shouldRefreshNow: shouldRefreshNow))
+
+            return invalidTokenEvent.asDriver(onErrorDriveWith: Driver.empty())
+        }
+
+        let refreshProcessFeedback: Feedback = react(query: { $0.isRefreshing }, effects: { token in
+            refreshToken(token.value)
+                .map { Event<Token>.tokenRefreshed(.success($0)) }
+                .asDriver(onErrorRecover: { Driver.just(Event<Token>.tokenRefreshed(SingleEvent.error($0))) })
+        })
+
+        return { state in
+            return Driver.merge(initiateRefreshProcessFeedback(state), refreshProcessFeedback(state))
+        }
+    }
+
+    /**
+     Implementation of OAuth feedback loops with in memory token storage and optional mirroring of that state
+     in some external persistent storage by using `OAuthExecutor.state`.
+    */
+    public static func system(
+        initialToken: Token,
+        refreshToken: @escaping (Token) -> Single<OAuthResponse<Token>>,
+        shouldRefreshNow: @escaping (Token) -> Bool = { _ in false }
+    ) -> Observable<OAuthExecutor<Token>> {
+        return Observable.create { observer in
+            let system = Driver.system(
+                initialState: .fresh(Version(initialToken)), reduce: TokenState.reduce,
+                feedback: feedback(
+                    refreshToken: refreshToken,
+                    shouldRefreshNow: shouldRefreshNow,
+                    authenticated: { observer.on(.next($0)) }
+                )
+            )
+
+            return system.drive()
+        }
+    }
+}
+
+extension TokenState {
+    var isRefreshing: Version<Token>? {
+        if case let .refreshing(version) = self {
+            return version
+        }
+        return nil
+    }
+
+    var token: Version<Token> {
+        switch self {
+        case let .fresh(version):
+            return version
+        case let .refreshing(version):
+            return version
+        case let .refreshFailed(version, _):
+            return version
+        case let .tokenInvalidated(version):
+            return version
+        }
+    }
+}
+
+public struct OAuthExecutor<Token: Equatable> {
+    public let state: Driver<TokenState<Token>>
+    
+    fileprivate let refreshToken: (Version<Token>) -> ()
+    fileprivate let shouldRefreshNow: (Token) -> Bool
+
+    fileprivate init(state: Driver<TokenState<Token>>, refreshToken: @escaping (Version<Token>) -> (), shouldRefreshNow: @escaping (Token) -> Bool) {
+        self.state = state
+        self.refreshToken = refreshToken
+        self.shouldRefreshNow = shouldRefreshNow
+    }
+
+    public func authenticate<Payload>(request: @escaping (Single<Token>) -> Single<OAuthResponse<Payload>>) -> Single<OAuthResponse<Payload>> {
+        func makeAuthenticatedRequest(token: Version<Token>, canRefresh: Bool) -> Single<OAuthResponse<Payload>> {
+            return request(Single.just(token.value)).flatMap { result in
+                switch result {
+                case .success:
+                    return Single.just(result)
+                case .tokenInvalidated:
+                    if !canRefresh {
+                        return Single.just(.tokenInvalidated)
+                    }
+                    return refreshAndTryToFetchNew(invalidToken: token)
+                }
+            }
+        }
+
+        func refreshAndTryToFetchNew(invalidToken: Version<Token>) -> Single<OAuthResponse<Payload>> {
+            return self.state.asObservable()
+                .filter { !($0.token == invalidToken) }
+                .do(onSubscribed: {
+                    self.refreshToken(invalidToken)
+                })
+                .take(1)
+                .asSingle()
+                .flatMap { currentState in
+                    switch currentState {
+                    case let .fresh(version):
+                        return makeAuthenticatedRequest(token: version, canRefresh: false)
+                    case .refreshing:
+                        return Single.just(.tokenInvalidated)
+                    case let .refreshFailed(_, error):
+                        return Single.error(error)
+                    case .tokenInvalidated:
+                        return Single.just(.tokenInvalidated)
+                    }
+            }
+        }
+
+        return state.asObservable()
+            .flatMapLatest { state -> Observable<Single<OAuthResponse<Payload>>> in
+                switch state {
+                case let .fresh(version):
+                    if self.shouldRefreshNow(version.value) {
+                        return Observable.just(refreshAndTryToFetchNew(invalidToken: version))
+                    }
+                    return Observable.just(makeAuthenticatedRequest(token: version, canRefresh: true))
+                case .refreshing(_):
+                    return Observable.empty()
+                case let .refreshFailed(version, _):
+                    return Observable.just(refreshAndTryToFetchNew(invalidToken: version))
+                case .tokenInvalidated:
+                    return Observable.just(Single.just(.tokenInvalidated))
+                }
+            }
+            .take(1)
+            .asSingle()
+            .flatMap { $0 }
+
+        }
+}

--- a/Sources/RxOAuth/Version.swift
+++ b/Sources/RxOAuth/Version.swift
@@ -1,0 +1,17 @@
+import class Foundation.NSObject
+
+public struct Version<Value>: Equatable {
+    fileprivate let mutation: NSObject
+    public let value: Value
+
+    public init(_ value: Value) {
+        self.mutation = NSObject()
+        self.value = value
+    }
+}
+
+extension Version {
+    public static func == (lhs: Version<Value>, rhs: Version<Value>) -> Bool {
+        return lhs.mutation == rhs.mutation
+    }
+}

--- a/Tests/RxOAuthTests/RxOAuthTests.swift
+++ b/Tests/RxOAuthTests/RxOAuthTests.swift
@@ -1,0 +1,796 @@
+//
+//  RxOAuthTests.swift
+//  RxFeedback
+//
+//  Created by Krunoslav Zaher on 5/9/17.
+//  Copyright © 2017 Krunoslav Zaher. All rights reserved.
+//
+
+import Foundation
+import XCTest
+import RxFeedback
+import RxOAuth
+import RxSwift
+import RxCocoa
+import RxTest
+
+class RxOAuthTests: XCTestCase {
+
+}
+
+// Let's use just a simple Int for tests
+// Token value is clock value until token is valid
+typealias OAuthToken = Int
+
+extension RxOAuthTests {
+
+    func testBasicRequest() {
+        let scheduler = TestScheduler(initialClock: 0, simulateProcessingDelay: false)
+
+        driveOnScheduler(scheduler) {
+            let tokenExecutor = OAuth.system(
+                initialToken: 300,
+                refreshToken: scheduler.refereshTokenFatalError,
+                shouldRefreshNow: { _ in false })
+
+            var trace: CommunicationTrace! = nil
+            
+            let res = scheduler.start { () -> Observable<TokenState<OAuthToken>> in
+                tokenExecutor.asObservable().flatMap { executor -> Observable<TokenState<OAuthToken>> in
+
+                    trace = CommunicationTrace(scheduler: scheduler, executor: executor)
+                    
+                    scheduler.scheduleAt(210) {
+                        trace.request(responses: [
+                            OAuthResponse<Payload>.success("Hi")
+                            ])
+                    }
+
+                    return executor.state.asObservable()
+                }
+            }
+
+            XCTAssertEqual(res.events, [
+                next(200, .fresh(Version(300)))
+                ])
+
+            XCTAssertEqual(trace.requests, [
+                Request(time: 220, event: .success(OAuthResponse.success("Hi")))
+                ])
+        }
+    }
+
+    func testBasicRequest_Parallel() {
+        let scheduler = TestScheduler(initialClock: 0, simulateProcessingDelay: false)
+
+        driveOnScheduler(scheduler) {
+            let tokenExecutor = OAuth.system(
+                initialToken: 300,
+                refreshToken: scheduler.refereshTokenFatalError,
+                shouldRefreshNow: { _ in false })
+
+            var trace: CommunicationTrace! = nil
+
+            let res = scheduler.start { () -> Observable<TokenState<OAuthToken>> in
+                tokenExecutor.asObservable().flatMap { executor -> Observable<TokenState<OAuthToken>> in
+
+                    trace = CommunicationTrace(scheduler: scheduler, executor: executor)
+
+                    scheduler.scheduleAt(210) {
+                        trace.request(responses: [
+                            OAuthResponse<Payload>.success("Hi")
+                            ])
+                    }
+
+                    scheduler.scheduleAt(215) {
+                        trace.request(responses: [
+                            OAuthResponse<Payload>.success("Hi2")
+                            ])
+                    }
+
+                    return executor.state.asObservable()
+                }
+            }
+
+            XCTAssertEqual(res.events, [
+                next(200, .fresh(Version(300)))
+                ])
+
+            XCTAssertEqual(trace.requests, [
+                Request(time: 220, event: .success(OAuthResponse.success("Hi"))),
+                Request(time: 225, event: .success(OAuthResponse.success("Hi2"))),
+                ])
+        }
+    }
+
+    func testBasicTokenExpired_ByDate_RefreshSucceeded() {
+        let scheduler = TestScheduler(initialClock: 0, simulateProcessingDelay: false)
+
+        driveOnScheduler(scheduler) {
+            let tokenExecutor = OAuth.system(
+                initialToken: 300,
+                refreshToken: scheduler.refreshTokenSuccess,
+                shouldRefreshNow: { value in value < scheduler.clock })
+
+            var trace: CommunicationTrace! = nil
+
+            let res = scheduler.start { () -> Observable<TokenState<OAuthToken>> in
+                tokenExecutor.asObservable().flatMap { executor -> Observable<TokenState<OAuthToken>> in
+
+                    trace = CommunicationTrace(scheduler: scheduler, executor: executor)
+
+                    scheduler.scheduleAt(500) {
+                        trace.request(responses: [
+                            OAuthResponse<Payload>.success("Hi")
+                            ])
+                    }
+
+                    return executor.state.asObservable()
+                }
+            }
+
+            XCTAssertEqual(res.events, [
+                next(200, .fresh(Version(300))),
+                next(500, .refreshing(Version(300))),
+                next(503, .fresh(Version(700)))
+                ])
+
+            XCTAssertEqual(trace.requests, [
+                Request(time: 513, event: .success(OAuthResponse.success("Hi")))
+                ])
+        }
+    }
+    
+    func testBasicTokenExpired_RefreshSucceeded() {
+        let scheduler = TestScheduler(initialClock: 0, simulateProcessingDelay: false)
+
+        driveOnScheduler(scheduler) {
+            let tokenExecutor = OAuth.system(
+                initialToken: 300,
+                refreshToken: scheduler.refreshTokenSuccess,
+                shouldRefreshNow: { _ in false })
+
+            var trace: CommunicationTrace! = nil
+
+            let res = scheduler.start { () -> Observable<TokenState<OAuthToken>> in
+                tokenExecutor.asObservable().flatMap { executor -> Observable<TokenState<OAuthToken>> in
+
+                    trace = CommunicationTrace(scheduler: scheduler, executor: executor)
+
+                    scheduler.scheduleAt(500) {
+                        trace.request(responses: [
+                            OAuthResponse<Payload>.tokenInvalidated,
+                            OAuthResponse<Payload>.success("Hi")
+                            ])
+                    }
+
+                    return executor.state.asObservable()
+                }
+            }
+
+            XCTAssertEqual(res.events, [
+                next(200, .fresh(Version(300))),
+                next(510, .refreshing(Version(300))),
+                next(513, .fresh(Version(710)))
+                ])
+
+            XCTAssertEqual(trace.requests, [
+                Request(time: 523, event: .success(OAuthResponse.success("Hi")))
+                ])
+        }
+    }
+
+    func testBasicTokenExpired_RefreshSucceeded_WaitingForInFlightRequest() {
+        let scheduler = TestScheduler(initialClock: 0, simulateProcessingDelay: false)
+
+        driveOnScheduler(scheduler) {
+            let tokenExecutor = OAuth.system(
+                initialToken: 300,
+                refreshToken: scheduler.refreshTokenSuccess,
+                shouldRefreshNow: { _ in false })
+
+            var trace: CommunicationTrace! = nil
+
+            let res = scheduler.start { () -> Observable<TokenState<OAuthToken>> in
+                tokenExecutor.asObservable().flatMap { executor -> Observable<TokenState<OAuthToken>> in
+
+                    trace = CommunicationTrace(scheduler: scheduler, executor: executor)
+
+                    scheduler.scheduleAt(500) {
+                        trace.request(responses: [
+                            OAuthResponse<Payload>.tokenInvalidated,
+                            OAuthResponse<Payload>.success("Hi")
+                            ])
+                    }
+
+                    scheduler.scheduleAt(511) {
+                        trace.request(responses: [
+                            OAuthResponse<Payload>.success("Hi2")
+                            ])
+                    }
+
+                    return executor.state.asObservable()
+                }
+            }
+
+            XCTAssertEqual(res.events, [
+                next(200, .fresh(Version(300))),
+                next(510, .refreshing(Version(300))),
+                next(513, .fresh(Version(710)))
+                ])
+
+            XCTAssertEqual(trace.requests, [
+                Request(time: 523, event: .success(OAuthResponse.success("Hi"))),
+                Request(time: 523, event: .success(OAuthResponse.success("Hi2"))),
+                ])
+        }
+    }
+
+    func testBasicTokenExpired_RefreshFailed_InvalidToken() {
+        let scheduler = TestScheduler(initialClock: 0, simulateProcessingDelay: false)
+
+        driveOnScheduler(scheduler) {
+            let tokenExecutor = OAuth.system(
+                initialToken: 300,
+                refreshToken: scheduler.refreshTokenInvalid,
+                shouldRefreshNow: { _ in false })
+
+            var trace: CommunicationTrace! = nil
+
+            let res = scheduler.start { () -> Observable<TokenState<OAuthToken>> in
+                tokenExecutor.asObservable().flatMap { executor -> Observable<TokenState<OAuthToken>> in
+
+                    trace = CommunicationTrace(scheduler: scheduler, executor: executor)
+
+                    scheduler.scheduleAt(500) {
+                        trace.request(responses: [
+                            OAuthResponse<Payload>.tokenInvalidated,
+                            ])
+                    }
+
+                    return executor.state.asObservable()
+                }
+            }
+
+            XCTAssertEqual(res.events, [
+                next(200, .fresh(Version(300))),
+                next(510, .refreshing(Version(300))),
+                next(513, .tokenInvalidated(Version(300)))
+                ])
+
+            XCTAssertEqual(trace.requests, [
+                Request(time: 513, event: .success(OAuthResponse.tokenInvalidated))
+                ])
+        }
+    }
+
+    func testBasicTokenExpired_RefreshFailed_InvalidToken_WaitingForInFlightRequest() {
+        let scheduler = TestScheduler(initialClock: 0, simulateProcessingDelay: false)
+
+        driveOnScheduler(scheduler) {
+            let tokenExecutor = OAuth.system(
+                initialToken: 300,
+                refreshToken: scheduler.refreshTokenInvalid,
+                shouldRefreshNow: { _ in false })
+
+            var trace: CommunicationTrace! = nil
+
+            let res = scheduler.start { () -> Observable<TokenState<OAuthToken>> in
+                tokenExecutor.asObservable().flatMap { executor -> Observable<TokenState<OAuthToken>> in
+
+                    trace = CommunicationTrace(scheduler: scheduler, executor: executor)
+
+                    scheduler.scheduleAt(500) {
+                        trace.request(responses: [
+                            OAuthResponse<Payload>.tokenInvalidated,
+                            ])
+                    }
+
+                    scheduler.scheduleAt(511) {
+                        trace.request(responses: [
+                            ])
+                    }
+
+                    return executor.state.asObservable()
+                }
+            }
+
+            XCTAssertEqual(res.events, [
+                next(200, .fresh(Version(300))),
+                next(510, .refreshing(Version(300))),
+                next(513, .tokenInvalidated(Version(300)))
+                ])
+
+            XCTAssertEqual(trace.requests, [
+                Request(time: 513, event: .success(OAuthResponse.tokenInvalidated)),
+                Request(time: 513, event: .success(OAuthResponse.tokenInvalidated)),
+                ])
+        }
+    }
+
+    func testBasicTokenExpired_RefreshFailed_InvalidToken_Parallel() {
+        let scheduler = TestScheduler(initialClock: 0, simulateProcessingDelay: false)
+
+        driveOnScheduler(scheduler) {
+            let tokenExecutor = OAuth.system(
+                initialToken: 300,
+                refreshToken: scheduler.refreshTokenInvalid,
+                shouldRefreshNow: { _ in false })
+
+            var trace: CommunicationTrace! = nil
+
+            let res = scheduler.start { () -> Observable<TokenState<OAuthToken>> in
+                tokenExecutor.asObservable().flatMap { executor -> Observable<TokenState<OAuthToken>> in
+
+                    trace = CommunicationTrace(scheduler: scheduler, executor: executor)
+
+                    scheduler.scheduleAt(500) {
+                        trace.request(responses: [
+                            OAuthResponse<Payload>.tokenInvalidated,
+                            ])
+                    }
+
+                    scheduler.scheduleAt(502) {
+                        trace.request(responses: [
+                            OAuthResponse<Payload>.tokenInvalidated,
+                            ])
+                    }
+
+                    return executor.state.asObservable()
+                }
+            }
+
+            XCTAssertEqual(res.events, [
+                next(200, .fresh(Version(300))),
+                next(510, .refreshing(Version(300))),
+                next(512, .refreshing(Version(300))),
+                next(513, .tokenInvalidated(Version(300)))
+                ])
+
+            XCTAssertEqual(trace.requests, [
+                Request(time: 513, event: .success(OAuthResponse.tokenInvalidated)),
+                Request(time: 513, event: .success(OAuthResponse.tokenInvalidated)),
+                ])
+        }
+    }
+
+    func testBasicTokenExpired_RefreshFailed_InvalidToken_ThenNext() {
+        let scheduler = TestScheduler(initialClock: 0, simulateProcessingDelay: false)
+
+        driveOnScheduler(scheduler) {
+            let tokenExecutor = OAuth.system(
+                initialToken: 300,
+                refreshToken: scheduler.refreshTokenInvalid,
+                shouldRefreshNow: { _ in false })
+
+            var trace: CommunicationTrace! = nil
+
+            let res = scheduler.start { () -> Observable<TokenState<OAuthToken>> in
+                tokenExecutor.asObservable().flatMap { executor -> Observable<TokenState<OAuthToken>> in
+
+                    trace = CommunicationTrace(scheduler: scheduler, executor: executor)
+
+                    scheduler.scheduleAt(500) {
+                        trace.request(responses: [
+                            OAuthResponse<Payload>.tokenInvalidated,
+                            ])
+                    }
+
+                    scheduler.scheduleAt(600) {
+                        trace.request(responses: [
+                            ])
+                    }
+
+                    return executor.state.asObservable()
+                }
+            }
+
+            XCTAssertEqual(res.events, [
+                next(200, .fresh(Version(300))),
+                next(510, .refreshing(Version(300))),
+                next(513, .tokenInvalidated(Version(300)))
+                ])
+
+            XCTAssertEqual(trace.requests, [
+                Request(time: 513, event: .success(OAuthResponse.tokenInvalidated)),
+                Request(time: 600, event: .success(OAuthResponse.tokenInvalidated)),
+                ])
+        }
+    }
+
+    func testBasicTokenExpired_RefreshFailed_SomeUnimportantError() {
+        let scheduler = TestScheduler(initialClock: 0, simulateProcessingDelay: false)
+
+        driveOnScheduler(scheduler) {
+            let tokenExecutor = OAuth.system(
+                initialToken: 300,
+                refreshToken: scheduler.refreshTokenError,
+                shouldRefreshNow: { _ in false })
+
+            var trace: CommunicationTrace! = nil
+
+            let res = scheduler.start { () -> Observable<TokenState<OAuthToken>> in
+                tokenExecutor.asObservable().flatMap { executor -> Observable<TokenState<OAuthToken>> in
+
+                    trace = CommunicationTrace(scheduler: scheduler, executor: executor)
+
+                    scheduler.scheduleAt(500) {
+                        trace.request(responses: [
+                            OAuthResponse<Payload>.tokenInvalidated,
+                            ])
+                    }
+
+                    return executor.state.asObservable()
+                }
+            }
+
+            XCTAssertEqual(res.events, [
+                next(200, .fresh(Version(300))),
+                next(510, .refreshing(Version(300))),
+                next(513, .refreshFailed(Version(300), lastError: SomeWeirdWhoCaresError.Idont))
+                ])
+
+            XCTAssertEqual(trace.requests, [
+                Request(time: 513, event: .error(SomeWeirdWhoCaresError.Idont))
+                ])
+        }
+    }
+
+    func testBasicTokenExpired_RefreshFailed_SomeUnimportantError_WaitingForInFlightRequest() {
+        let scheduler = TestScheduler(initialClock: 0, simulateProcessingDelay: false)
+
+        driveOnScheduler(scheduler) {
+            let tokenExecutor = OAuth.system(
+                initialToken: 300,
+                refreshToken: scheduler.refreshTokenError,
+                shouldRefreshNow: { _ in false })
+
+            var trace: CommunicationTrace! = nil
+
+            let res = scheduler.start { () -> Observable<TokenState<OAuthToken>> in
+                tokenExecutor.asObservable().flatMap { executor -> Observable<TokenState<OAuthToken>> in
+
+                    trace = CommunicationTrace(scheduler: scheduler, executor: executor)
+
+                    scheduler.scheduleAt(500) {
+                        trace.request(responses: [
+                            OAuthResponse<Payload>.tokenInvalidated,
+                            ])
+                    }
+
+                    scheduler.scheduleAt(511) {
+                        trace.request(responses: [
+                            ])
+                    }
+
+                    return executor.state.asObservable()
+                }
+            }
+
+            XCTAssertEqual(res.events, [
+                next(200, .fresh(Version(300))),
+                next(510, .refreshing(Version(300))),
+                next(513, .refreshFailed(Version(300), lastError: SomeWeirdWhoCaresError.Idont)),
+                next(513, .refreshing(Version(300))),
+                next(516, .refreshFailed(Version(300), lastError: SomeWeirdWhoCaresError.Idont)),
+                ])
+
+            XCTAssertEqual(trace.requests, [
+                Request(time: 513, event: .error(SomeWeirdWhoCaresError.Idont)),
+                Request(time: 516, event: .error(SomeWeirdWhoCaresError.Idont))
+                ])
+        }
+    }
+    
+    func testBasicTokenExpired_RefreshFailed_SomeUnimportantError_ParallelRequests() {
+        let scheduler = TestScheduler(initialClock: 0, simulateProcessingDelay: false)
+
+        driveOnScheduler(scheduler) {
+            let tokenExecutor = OAuth.system(
+                initialToken: 300,
+                refreshToken: scheduler.refreshTokenError,
+                shouldRefreshNow: { _ in false })
+
+            var trace: CommunicationTrace! = nil
+
+            let res = scheduler.start { () -> Observable<TokenState<OAuthToken>> in
+                tokenExecutor.asObservable().flatMap { executor -> Observable<TokenState<OAuthToken>> in
+
+                    trace = CommunicationTrace(scheduler: scheduler, executor: executor)
+
+                    scheduler.scheduleAt(500) {
+                        trace.request(responses: [
+                            OAuthResponse<Payload>.tokenInvalidated,
+                            ])
+                    }
+
+                    scheduler.scheduleAt(502) {
+                        trace.request(responses: [
+                            OAuthResponse<Payload>.tokenInvalidated,
+                            ])
+                    }
+
+
+                    return executor.state.asObservable()
+                }
+            }
+
+            XCTAssertEqual(res.events, [
+                next(200, .fresh(Version(300))),
+                next(510, .refreshing(Version(300))),
+                next(512, .refreshing(Version(300))),
+                next(513, .refreshFailed(Version(300), lastError: SomeWeirdWhoCaresError.Idont)),
+                ])
+
+            XCTAssertEqual(trace.requests, [
+                Request(time: 513, event: .error(SomeWeirdWhoCaresError.Idont)),
+                Request(time: 513, event: .error(SomeWeirdWhoCaresError.Idont))
+                ])
+        }
+    }
+
+    func testBasicTokenExpired_RefreshFailed_SomeUnimportantError_ThenSuccess() {
+        let scheduler = TestScheduler(initialClock: 0, simulateProcessingDelay: false)
+
+        driveOnScheduler(scheduler) {
+            let tokenExecutor = OAuth.system(
+                initialToken: 300,
+                refreshToken: scheduler.refreshTokenResponses([
+                    .error(SomeWeirdWhoCaresError.Idont),
+                    .success(.success(800))
+                    ]),
+                shouldRefreshNow: { _ in false })
+
+            var trace: CommunicationTrace! = nil
+
+            let res = scheduler.start { () -> Observable<TokenState<OAuthToken>> in
+                tokenExecutor.asObservable().flatMap { executor -> Observable<TokenState<OAuthToken>> in
+
+                    trace = CommunicationTrace(scheduler: scheduler, executor: executor)
+
+                    scheduler.scheduleAt(500) {
+                        trace.request(responses: [
+                            OAuthResponse<Payload>.tokenInvalidated,
+                            ])
+                    }
+
+                    scheduler.scheduleAt(600) {
+                        trace.request(responses: [
+                            OAuthResponse<Payload>.success("Hi again")
+                            ])
+                    }
+
+                    return executor.state.asObservable()
+                }
+            }
+
+            XCTAssertEqual(res.events, [
+                next(200, .fresh(Version(300))),
+                next(510, .refreshing(Version(300))),
+                next(513, .refreshFailed(Version(300), lastError: SomeWeirdWhoCaresError.Idont)),
+                next(600, .refreshing(Version(300))),
+                next(603, .fresh(Version(800)))
+                ])
+
+            XCTAssertEqual(trace.requests, [
+                Request(time: 513, event: .error(SomeWeirdWhoCaresError.Idont)),
+                Request(time: 613, event: .success(.success("Hi again"))),
+                ])
+        }
+    }
+
+    func testBasicTokenExpired_RefreshFailed_SomeUnimportantError_UnimportantError() {
+        let scheduler = TestScheduler(initialClock: 0, simulateProcessingDelay: false)
+
+        driveOnScheduler(scheduler) {
+            let tokenExecutor = OAuth.system(
+                initialToken: 300,
+                refreshToken: scheduler.refreshTokenResponses([
+                    .error(SomeWeirdWhoCaresError.Idont),
+                    .error(SomeWeirdWhoCaresError.Idont),
+                    ]),
+                shouldRefreshNow: { _ in false })
+
+            var trace: CommunicationTrace! = nil
+
+            let res = scheduler.start { () -> Observable<TokenState<OAuthToken>> in
+                tokenExecutor.asObservable().flatMap { executor -> Observable<TokenState<OAuthToken>> in
+
+                    trace = CommunicationTrace(scheduler: scheduler, executor: executor)
+
+                    scheduler.scheduleAt(500) {
+                        trace.request(responses: [
+                            OAuthResponse<Payload>.tokenInvalidated,
+                            ])
+                    }
+
+                    scheduler.scheduleAt(600) {
+                        trace.request(responses: [
+                            ])
+                    }
+
+                    return executor.state.asObservable()
+                }
+            }
+
+            XCTAssertEqual(res.events, [
+                next(200, .fresh(Version(300))),
+                next(510, .refreshing(Version(300))),
+                next(513, .refreshFailed(Version(300), lastError: SomeWeirdWhoCaresError.Idont)),
+                next(600, .refreshing(Version(300))),
+                next(603, .refreshFailed(Version(300), lastError: SomeWeirdWhoCaresError.Idont)),
+                ])
+
+            XCTAssertEqual(trace.requests, [
+                Request(time: 513, event: .error(SomeWeirdWhoCaresError.Idont)),
+                Request(time: 603, event: .error(SomeWeirdWhoCaresError.Idont)),
+                ])
+        }
+    }
+
+    func testBasicTokenExpired_RefreshFailed_SomeUnimportantError_InvalidatedToken() {
+        let scheduler = TestScheduler(initialClock: 0, simulateProcessingDelay: false)
+
+        driveOnScheduler(scheduler) {
+            let tokenExecutor = OAuth.system(
+                initialToken: 300,
+                refreshToken: scheduler.refreshTokenResponses([
+                    .error(SomeWeirdWhoCaresError.Idont),
+                    .success(.tokenInvalidated)
+                    ]),
+                shouldRefreshNow: { _ in false })
+
+            var trace: CommunicationTrace! = nil
+
+            let res = scheduler.start { () -> Observable<TokenState<OAuthToken>> in
+                tokenExecutor.asObservable().flatMap { executor -> Observable<TokenState<OAuthToken>> in
+
+                    trace = CommunicationTrace(scheduler: scheduler, executor: executor)
+
+                    scheduler.scheduleAt(500) {
+                        trace.request(responses: [
+                            OAuthResponse<Payload>.tokenInvalidated,
+                            ])
+                    }
+
+                    scheduler.scheduleAt(600) {
+                        trace.request(responses: [
+                            ])
+                    }
+
+                    return executor.state.asObservable()
+                }
+            }
+
+            XCTAssertEqual(res.events, [
+                next(200, .fresh(Version(300))),
+                next(510, .refreshing(Version(300))),
+                next(513, .refreshFailed(Version(300), lastError: SomeWeirdWhoCaresError.Idont)),
+                next(600, .refreshing(Version(300))),
+                next(603, .tokenInvalidated(Version(300))),
+                ])
+
+            XCTAssertEqual(trace.requests, [
+                Request(time: 513, event: .error(SomeWeirdWhoCaresError.Idont)),
+                Request(time: 603, event: .success(.tokenInvalidated)),
+                ])
+        }
+    }
+}
+
+extension TokenState: Equatable {
+    public static func == (lhs: TokenState<Token>, rhs: TokenState<Token>) -> Bool {
+        switch (lhs, rhs) {
+        case let (.fresh(lhs), .fresh(rhs)):
+            return lhs.value == rhs.value
+        case (.fresh, _):
+            return false
+        case let (.refreshing(lhs), .refreshing(rhs)):
+            return lhs.value == rhs.value
+        case (.refreshing, _):
+            return false
+        case let (.refreshFailed(lhs, lError), .refreshFailed(rhs, rError)):
+            return lhs.value == rhs.value && "\(lError)" == "\(rError)"
+        case (.refreshFailed, _):
+            return false
+        case let (.tokenInvalidated(lhs), .tokenInvalidated(rhs)):
+            return lhs.value == rhs.value
+        case (.tokenInvalidated, _):
+            return false
+        }
+    }
+}
+
+typealias Payload = String
+
+extension Request: Equatable {
+    public static func == (lhs: Request, rhs: Request) -> Bool {
+        return "\(lhs)" == "\(rhs)"
+    }
+}
+
+struct Request {
+    let time: TestScheduler.VirtualTime
+    let event: SingleEvent<OAuthResponse<Payload>>
+}
+
+class CommunicationTrace {
+    let scheduler: TestScheduler
+    let executor: OAuthExecutor<OAuthToken>
+    var requests: [Request] = []
+
+    init(scheduler: TestScheduler, executor: OAuthExecutor<OAuthToken>) {
+        self.scheduler = scheduler
+        self.executor = executor
+    }
+
+    func request(responses: [OAuthResponse<Payload>]) {
+        var numberOfRequests = 0
+        _ = Single.deferred { () -> Single<OAuthResponse<Payload>> in
+                    return self.executor.authenticate(request: { token in token.flatMap { token in
+                            defer { numberOfRequests += 1 }
+                            if token < self.scheduler.clock {
+                                guard case .tokenInvalidated = responses[numberOfRequests] else {
+                                    fatalError("Token has expired, you have to return invalidated token")
+                                }
+                                return Single.just(OAuthResponse<Payload>.tokenInvalidated)
+                            }
+                            return Single.just(responses[numberOfRequests])
+                        }.delay(10.0, scheduler: self.scheduler)
+                    })
+                }
+                .subscribe { event in
+                    let request = Request(
+                        time: self.scheduler.clock,
+                        event: event
+                    )
+                    if numberOfRequests != responses.count {
+                        fatalError("Not all responses have been used")
+                    }
+                    self.requests.append(request)
+                }
+    }
+}
+
+enum SomeWeirdWhoCaresError: Error {
+    case Idont
+}
+
+extension TestScheduler {
+    func refereshTokenFatalError(token: OAuthToken) -> Single<OAuthResponse<OAuthToken>> {
+        fatalError()
+    }
+
+    func refreshTokenSuccess(token: OAuthToken) -> Single<OAuthResponse<OAuthToken>> {
+        return Single.deferred {
+            return Single.just(OAuthResponse.success(self.clock + 200))
+        }
+        .delay(3.0, scheduler: self)
+    }
+
+    func refreshTokenInvalid(token: OAuthToken) -> Single<OAuthResponse<OAuthToken>> {
+        return Single.deferred {
+                return Single.just(OAuthResponse.tokenInvalidated)
+            }
+            .delay(3.0, scheduler: self)
+    }
+
+    func refreshTokenError(token: OAuthToken) -> Single<OAuthResponse<OAuthToken>> {
+        return Single.deferred {
+                return Single.error(SomeWeirdWhoCaresError.Idont)
+            }
+            .delaySubscription(3.0, scheduler: self)
+    }
+
+    func refreshTokenResponses(_ responses: [SingleEvent<OAuthResponse<OAuthToken>>]) -> (_ token: OAuthToken) -> Single<OAuthResponse<OAuthToken>> {
+        var tried = 0
+        return { token in
+            return Single<OAuthResponse<OAuthToken>>.create { observer in
+                defer { tried += 1 }
+                observer(responses[tried])
+                return Disposables.create()
+            }
+            .delaySubscription(3.0, scheduler: self)
+        }
+    }
+}


### PR DESCRIPTION
This is an example of generic OAuth logic made by using `system` operator.

Generic OAuth logic is ~150 lines long in `Sources/RxOAuth/RxOAuth.swift`

There are also unit tests included, and it seems to work ok :)

* There is optional callback that enables validating token expiration date and preemptive token refresh `shouldRefreshNow`
* In case OAuth authenticated call returns `.tokenInvalidated`, oauth token is refreshed and original request is retried exactly once with the new token.
* Token is only invalidated in case token refresh call returns `.tokenInvalidated` (usually 401). This is to guard against buggy server implementations (been there, done that :) In case any other call returns `.tokenInvalidated` (usually 401), it will only initiate token refresh logic.
* There are no assumptions about OAuth token structure, it's a generic value type.

There are 2 ways how one could use this.

* Version where token persistence is handled manually -> `OAuth.feedback` provides feedback loops for that external state storage.
* Version where external token persistence can be updated with latest token version from `OAuthExecutor.state`. E.g. In case of logout, OAuthExecutor.state would return `.tokenInvalidated`.  This is `OAuth.system` interface.

This is the first version to try out the concept. Doesn't look too bad :) Maybe it can be simplified more.